### PR TITLE
Hide underlying implementation and fix bz1328588

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+docker-lvm-plugin


### PR DESCRIPTION
- hide the underlying implementation detail that we use `lv*` tools or `mkfs` by returning generic error messages (we will log details in syslog in a follow up PR)
- Fix https://bugzilla.redhat.com/show_bug.cgi?id=1328588#c15
- Cleanup the volume if there's an error on create time
- Cleanup the mountpoint if there's an error on create time
- Fix .gitignore (add the binary output)
- Error out directly if no `--size` or empty `--size` is provided (otherwise we'll show `lvcreate` specific error:

 `Error response from daemon: create test6: VolumeDriver.Create: Please specify either size or extents.
     Run 'lvcreate --help' for more information.`)

ping @rhvgoyal @shishir-a412ed @rhatdan @mrunalp

Signed-off-by: Antonio Murdaca <runcom@redhat.com>