### PR TITLE
added basic Capabilities function to the driver

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -340,3 +340,9 @@ func resp(r interface{}) volume.Response {
 		return volume.Response{Err: "bad value writing response"}
 	}
 }
+
+func (l *lvmDriver) Capabilities(req volume.Request) volume.Response {
+    var res volume.Response
+    res.Capabilities = volume.Capability{Scope: "local"}
+    return res
+}


### PR DESCRIPTION
fix for issue #13 

from https://github.com/calavera/docker-volume-glusterfs/pull/33/commits/5a818b221fd0d4ad7a452945cbeda1855b82fbd1

