### PR TITLE
LUKS volume encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Following options can be passed using `-o` or `--opt`
 --opt size
 --opt thinpool
 --opt snapshot
+--opt keyfile
 ``` 
 Please see examples below on how to use these options.
 
@@ -77,11 +78,14 @@ This will create a lvm volume named `foobar` of size 208 MB (0.2 GB).
 docker volume create -d lvm --opt size=0.2G --opt thinpool=mythinpool thin_vol
 ```
 This will create a thinly-provisioned lvm volume named `thin_vol` in mythinpool.
-
 ```bash
 docker volume create -d lvm --opt snapshot=foobar --opt size=100M foobar_snapshot
 ```
 This will create a snapshot volume of `foobar` named `foobar_snapshot`. For thin snapshots, use the same command above but don't specify a size.
+```bash
+docker volume create -d lvm --opt size=0.2G --opt keyfile=/root/key.bin crypt_vol
+```
+This will create a LUKS encrypted lvm volume named `crypt_vol` with the contents of `/root/key.bin` as a binary passphrase. Snapshots of encrypted volumes use the same key file. The key file must be present when the volume is created, and when it is mounted to a container.
 
 ## Volume List
 Use `docker volume ls --help` for more information.

--- a/man/docker-lvm-plugin.8.md
+++ b/man/docker-lvm-plugin.8.md
@@ -71,6 +71,10 @@ This will create a thinly-provisioned lvm volume named `thin_vol` in mythinpool.
 docker volume create -d lvm --opt snapshot=foobar --opt size=100M foobar_snapshot
 ```
 This will create a snapshot volume of `foobar` named `foobar_snapshot`. For thin snapshots, use the same command above but don't specify a size.
+```bash
+docker volume create -d lvm --opt size=0.2G --opt keyfile=/root/key.bin crypt_vol
+```
+This will create a LUKS encrypted lvm volume named `crypt_vol` with the contents of `/root/key.bin` as a binary passphrase. Snapshots of encrypted volumes use the same key file. The key file must be present when the volume is created, and when it is mounted to a container.
 
 **Volume List**
 ```bash

--- a/utils.go
+++ b/utils.go
@@ -143,3 +143,29 @@ func lvdisplayGrep(vgName, lvName, keyword string) (bool, error) {
 func isThinlyProvisioned(vgName, lvName string) (bool, error) {
 	return lvdisplayGrep(vgName, lvName, "LV Pool")
 }
+
+func keyFileExists(keyFile string) error {
+	if _, err := os.Stat(keyFile); os.IsNotExist(err) {
+		return fmt.Errorf("key file does not exist: %s", keyFile)
+	}
+	return nil
+}
+
+func cryptsetupInstalled() error {
+	if _, err := exec.LookPath("cryptsetup"); err != nil {
+		return fmt.Errorf("'cryptsetup' executable not found")
+	}
+	return nil
+}
+
+func logicalDevice(vgName, lvName string) string {
+	return fmt.Sprintf("/dev/%s/%s", vgName, lvName)
+}
+
+func luksDevice(lvName string) string {
+	return fmt.Sprintf("/dev/mapper/%s", luksDeviceName(lvName))
+}
+
+func luksDeviceName(lvName string) string {
+	return fmt.Sprintf("luks-%s", lvName)
+}


### PR DESCRIPTION
This makes use of https://gitlab.com/cryptsetup/cryptsetup/ to apply LUKS encryption to volumes when they are created. Two new options were added to support the feature:

```
dd if=/dev/urandom of=/root/luks-key.bin bs=4096 count=1
docker volume create -d lvm --name foobar --opt size=5G --opt thinpool=volume-thinpool --opt crypt=luks --opt keyfile=/root/luks-key.bin
```

The key file must be available when the volume is created, and when it is mounted. I chose to use key files so there would be no storing of secrets within docker-lvm-plugin.

I am not a go expert, so I would appreciate any pointers to improve the code. If this PR looks good code wise, I will update the README.md as well.