### PR TITLE
Install docker-lvm-plugin config only if it doesn't exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ lvm-plugin-build: main.go driver.go
 
 .PHONY: install
 install:
-	install -D -m 644 etc/docker/docker-lvm-plugin $(SYSCONFDIR)/docker-lvm-plugin
+	if [ ! -f "$(SYSCONFDIR)/docker-lvm-plugin" ]; then					\
+	   install -D -m 644 etc/docker/docker-lvm-plugin $(SYSCONFDIR)/docker-lvm-plugin;	\
+	fi
 	install -D -m 644 systemd/docker-lvm-plugin.service $(SYSTEMDIR)/docker-lvm-plugin.service
 	install -D -m 644 systemd/docker-lvm-plugin.socket $(SYSTEMDIR)/docker-lvm-plugin.socket
 	install -D -m 755 $(BINARY) $(BINDIR)/$(BINARY)


### PR DESCRIPTION
Signed-off-by: Shishir Mahajan <shishirm@nvidia.com>