### PR TITLE
Fix mkfs.xfs cannot create volumes due to existing filesystems

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -143,7 +143,7 @@ func (l *lvmDriver) Create(req *volume.CreateRequest) error {
 			device = luksDevice(req.Name)
 		}
 
-		cmd = exec.Command("mkfs.xfs", device)
+		cmd = exec.Command("mkfs.xfs", "-f", device)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			l.logger.Err(fmt.Sprintf("Create: mkfs.xfs error: %s output %s", err, string(out)))
 			return fmt.Errorf("Error partitioning volume")


### PR DESCRIPTION
Whenever we delete and recreate a [Rancher](https://rancher.com/docs/rancher/v1.6/en/) (v1.6.21) container stack often LVM volumes cannot be recreated because mkfs.xfs refuses to overwrite existing filesystems and logs an error like the following:

```
Nov 21 16:35:55 atomic docker-lvm-plugin[3191]: Create: mkfs.xfs error: exit status 1 output mkfs.xfs: /dev/atomicos/mystack_mosquitto_cf159 appears to contain an existing filesystem (xfs_external_log).
                                                mkfs.xfs: Use the -f option to force overwrite.
```

See also this full [logging.txt](https://github.com/projectatomic/docker-lvm-plugin/files/2619871/logging.txt).

As a result the affected containers fail to start because their volumes cannot be recreated.

This PR modifies the docker-lvm-plugin by adding the -f option to mkfs.xfs command so this issue no longer occurs.

Do you think it is a good idea to force overwrite by default or should we make this configurable with a configuration option?

Additional environment details:

* CentOS Linux 7.1810
* docker-1.13.1-75.git8633870.el7.centos.x86_64
* AMD64 architecture
