### PR TITLE
Default to 'yes' for lvcreate prompts

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -67,7 +67,7 @@ func (l *lvmDriver) Create(req *volume.CreateRequest) error {
 		}
 	}
 
-	cmdArgs := []string{"-n", req.Name, "--setactivationskip", "n"}
+	cmdArgs := []string{"-y", "-n", req.Name, "--setactivationskip", "n"}
 	snap, ok := req.Options["snapshot"]
 	isSnapshot := ok && snap != ""
 	isThinSnap := false


### PR DESCRIPTION
Currently `lvcreate` detects `xfs` signature at the beginning of the volume and asks for a confirmation to zero it (the default behavior).
Because there is no `stdin` attached - confirmation is not given and `lvcreate` just creates the volume without zeroing its beginning.
This in turn leads to an error with `mkfs`.

Adding `-y` to `lvcreate` forces a yes answer to zeriong confirmation prompt and makes sure that volume beginning will be properly cleared.